### PR TITLE
add apis for channel service's persistence

### DIFF
--- a/src/proto/perun-wallet.proto
+++ b/src/proto/perun-wallet.proto
@@ -1,9 +1,10 @@
 syntax = "proto3";
 
 import "wire.proto";
-import "google/protobuf/empty.proto";
 
 package perunservice;
+
+option go_package = "./proto";
 
 // ChannelService running as a background worker providing core functionality
 // to interact with Perun channels.
@@ -14,9 +15,40 @@ service ChannelService {
   rpc UpdateChannel(ChannelUpdateRequest) returns (ChannelUpdateResponse);
   // Initiate channel closing.
   rpc CloseChannel(ChannelCloseRequest) returns (ChannelCloseResponse);
-  // Query the current state of the Channels.option
+  // Query the current state of the Channels
   rpc GetChannels(GetChannelsRequest) returns (GetChannelsResponse);
 
+  rpc RestoreChannels(RestoreChannelsRequest) returns (RestoreChannelsResponse);
+
+  rpc ClosePerunClient(ClosePerunClientRequest) returns (ClosePerunClientResponse);
+
+  rpc NewPerunClient(NewPerunClientRequest) returns (NewPerunClientResponse);
+}
+
+message RestoreChannelsRequest{
+  bytes data = 1;
+}
+
+message RestoreChannelsResponse{
+  bool accepted = 1;
+  bytes data = 2;
+}
+
+message ClosePerunClientRequest{
+  bytes data = 1;
+}
+
+message ClosePerunClientResponse{
+  bool accepted = 1;
+  bytes data = 2;
+}
+message NewPerunClientRequest{
+  bytes data = 1;
+}
+
+message NewPerunClientResponse{
+  bool accepted = 1;
+  bytes data = 2;
 }
 
 // Generic rejected message. Returned by any endpoint on failure.

--- a/src/proto/wire.proto
+++ b/src/proto/wire.proto
@@ -27,7 +27,7 @@ message Envelope {
   bytes sender = 1;
   // intended recipient of the message.
   bytes recipient = 2;
-  // msg should contain on the valid message types.
+  // msg should contain on the valid messaSge types.
   oneof msg {
     PingMsg ping_msg = 3;
     PongMsg pong_msg = 4;


### PR DESCRIPTION
Add  APIs to support persistence for channel-service.
### Newly added API:
* `RestoreChannels`: restores all channels saved in the underlying db
* `ClosePerunClient`: force close perun client without closing channels
* `NewPerunClient`: create a new perun client. Primarily intended for testing purposes. 

